### PR TITLE
feat: add GitHub workflow to validate pr titles follow conventional commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,12 @@
-# References
-<!-- Any issues or pull requests relevant to this pull request -->
+<!--
+Set the PR title to a meaningful commit message that:
+- follows the Conventional Commits specification (https://www.conventionalcommits.org).
+- is in imperative form.
 
+Template:
+<type>[optional scope]: <description>
+fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
+-->
 # Description
 <!-- Describe what this request will change/fix and provide any details 
 necessary for reviewers -->

--- a/.github/workflows/pr-title-checks.yaml
+++ b/.github/workflows/pr-title-checks.yaml
@@ -1,0 +1,25 @@
+name: "pr-title-checks"
+
+on:
+  pull_request_target:
+    types: ["edited", "opened", "reopened"]
+    branches: ["main"]
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  conventional-commits:
+    permissions:
+      # For amannn/action-semantic-pull-request
+      pull-requests: "read"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "amannn/action-semantic-pull-request@v5"
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+
+permissions: {}


### PR DESCRIPTION
# References
https://github.com/y-scope/yscope-log-viewer/pull/121

# Description
Merge ci workflow feature on my main branch and start doing testing.


